### PR TITLE
Support non-ASCII section/segment names

### DIFF
--- a/cavefinder/support/macho.py
+++ b/cavefinder/support/macho.py
@@ -313,8 +313,8 @@ class MachOSection(object, metaclass=CStruct):
 
     def __init__(self, stream: io.RawIOBase, header: MachOHeader):
         self.unpack_from_io(stream, header.endianness)
-        self.sectname = self.sectname.decode("ascii")
-        self.segname = self.segname.decode("ascii")
+        self.sectname = self.sectname.decode("ascii", "backslashreplace")
+        self.segname = self.segname.decode("ascii", "backslashreplace")
 
 
 class MachOSection32(MachOSection):


### PR DESCRIPTION
The current version of Starcraft 1 has a section named `b'__text\xee'` that causes this utility to fail when it tries to decode the name as ASCII. Escaping the offending bytes in the output feels like a reasonable way to handle this.